### PR TITLE
Use correct barrier to eliminate dead store elimination

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -43,6 +43,6 @@ void
 explicit_bzero(void *s, size_t len)
 {
   memset(s, '\0', len);
-  asm volatile ("":::"memory");
+  asm volatile (""::"g"(s):"memory");
 }
 #endif


### PR DESCRIPTION
This is super tricky.

Commonly in crypto code, one wants to clear keys and intermediate results of keys from the stack.  Unfortunately, a valid and useful compiler optimization exists called 'dead store elimination'.  Given that in C abstract machine, it's undefined behavior to hold onto a pointer to a variable after that variable goes out of scope, a compiler is allowed eliminate stores to a variable that isn't read again before it goes out of scope.  Practically speaking, this typically means that memset(0)'s of keys left on the stack get optimized out by the compiler at trivial optimization levels.

Previously, this code was changed to use explicit_bzero() to clear the keys, with a stub implementation added for the case where libc doesn't provide one.  The stub implementation unfortunately uses a memory *reordering* barrier rather than a store synchronization barrier.

This appears to have been copied out of glibc, but without the implicit understanding that this works for glibc since glibc only supports dynamic linking, and a compiler has practical issues optimizing across a dynamic library procedure linkage table call.  (This doesn't apply to memset like you might think, since the compiler has a deep knowledge as to how memset works in order to inline it and optimize it using vector registers, etc.)

Because of this, higher optimization levels still saw the memset(0)s being optimized away, despite using explicit_bzero().

Therefore, this patch adds the pointer to the buffer to the input operands of the empty asm (in addition to the memory clobber), forcing the otherwise dead store to make it's way into the generated instruction stream.

This technique can also be seen in the linux kernel here:

https://elixir.bootlin.com/linux/v4.4.70/source/include/linux/compiler-gcc.h#L29